### PR TITLE
add GH action to publish a specific next version

### DIFF
--- a/.github/workflows/publish-vsx-specific-next.yml
+++ b/.github/workflows/publish-vsx-specific-next.yml
@@ -1,0 +1,39 @@
+name: ovsx-solid---publish-vscode-built-in-extensions-specific-version-next
+on:
+  push:
+    branches:
+      - ovsx-publish-next
+env:
+  NODE_OPTIONS: --max-old-space-size=8192
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      OVSX_PAT: ${{ secrets.OVSX_PAT}}
+    steps:
+      - uses: actions/checkout@v1
+      - run: |
+          git submodule init
+          git submodule update
+        name: Checkout VS Code
+      # should be aligned with https://github.com/microsoft/vscode/blob/8031c495a65de120560d27703c415eb44c3a99a1/.github/workflows/ci.yml#L22-L32
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -y libxkbfile-dev pkg-config libsecret-1-dev libxss1 dbus xvfb libgtk-3-0
+          sudo cp vscode/build/azure-pipelines/linux/xvfb.init /etc/init.d/xvfb
+          sudo chmod +x /etc/init.d/xvfb
+          sudo update-rc.d xvfb defaults
+          sudo service xvfb start
+        name: Setup Build Environment
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10
+      - run: npx ovsx --version
+        name: Check ovsx version
+      - run: yarn
+        name: Bundle Extensions
+      - run: yarn package-vsix:next
+        name: Package Internediate Version of Extensions
+      - run: yarn publish:vsix
+        name: Publish Extensions to open-vsx.org

--- a/README.md
+++ b/README.md
@@ -121,7 +121,13 @@ After packaging the extensions as `.vsix` (see above), you may examine/test them
 
 ## Re-publishing vscode-builtin-extensions to open-vsx
 
-There is a GH action to help: `publish-vsx-specific-latest`. For this to work, the version to be published needs to be removed from open-vsx. Then one must push to branch `ovsx-publish`. We do not care about that branch - once publish is done, it can be reset the next time. Make sure the wanted solid version of the `vscode` git submodule is checked-out in the pushed change.
+### Solid version
+
+There is a GH action to help: `publish-vsx-specific-latest`. For this to work, the version to be published needs to be removed from open-vsx. Then one must push to branch `ovsx-publish`. Make sure the wanted solid version of the `vscode` git submodule is checked-out in the pushed change. We do not care about that branch - once publish is done, it can be reset the next time.
+
+### Intermediary (next) version
+
+There is a GH action to help: `publish-vsx-specific-next`. For this to work, the version to be published needs to be removed from open-vsx. Then one must push to branch `ovsx-publish-next`. Make sure the wanted intermediary version of the `vscode` git submodule is checked-out in the pushed change. We do not care about that branch - once publish is done, it can be reset the next time.
 
 ## License
 


### PR DESCRIPTION
This commit adds a GH action to publish an arbitrary next version of
the vscode-builtins: `publish-vsx-specific-next`. For this to work,
the version to be published needs to be removed from open-vsx, if
already present. Then one must push to branch `ovsx-publish-next`,
whatever they want built. e.g. the most recent master version of the
repo, but with a specific commit checked in the vscode git submodule.

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>

<a href="https://gitpod.io/#https://github.com/eclipse-theia/vscode-builtin-extensions/pull/44"><img src="https://gitpod.io/api/apps/github/pbs/github.com/eclipse-theia/vscode-builtin-extensions.git/2b0bea3dfdd56c380e3a07faef3ffd62601c8113.svg" /></a>

