### PR TITLE
Package extension even if icon is not present

### DIFF
--- a/src/package-vsix.js
+++ b/src/package-vsix.js
@@ -134,6 +134,17 @@ const repository = {
         pck.repository = repository;
         pck.version = version;
         pck.license = 'SEE LICENSE IN LICENSE-vscode.txt';
+
+        // Prevent 'vsce' packaging errors by removing the specified icon if it does not exist.
+        // When an icon is not provided a default icon will be applied by the registry.
+        const icon = pck.icon;
+        if (icon) {
+            const iconPath = extensions(extension, icon);
+            if (!fs.existsSync(iconPath)) {
+                delete pck.icon;
+            }
+        }
+
         if (tag === 'next') {
             pck.preview = true;
         }


### PR DESCRIPTION
If an extension specifies an icon in its package.json but the
specified file is not provided, 'vsce' executable will fail packaging

However it's quite common to have built-in extensions with no icon
so this fixes the issue by removing the icon property from the
package.json before packaging.

Once published the registry will apply a default icon.

Fixes: #59 

Signed-off-by: Alvaro Sanchez-Leon <alvaro.sanchez-leon@ericsson.com>