### PR TITLE
Add ms-vscode extensions to built-in extension pack

### DIFF
--- a/vscode-builtin-extensions/.gitignore
+++ b/vscode-builtin-extensions/.gitignore
@@ -1,1 +1,2 @@
 extensions
+builtin-extension-pack-*


### PR DESCRIPTION
Extensions using the `ms-vscode` name space are built-in extensions
although the source code is maintained outside the vscode repository.

This change hard-codes the known 'ms-vscode' extensions available in
the open vsx registry and includes them within the generated built-in
extension package.

The extension 'ms-vscode.vscode-js-profile-table' is not included in
this change as it's not passing validation checks i.e. no publisher,
no version. In addition it depends on additional extensions which are
using a proposed API which is subject to change.

Signed-off-by: Alvaro Sanchez-Leon <alvaro.sanchez-leon@ericsson.com>

<a href="https://gitpod.io/#https://github.com/eclipse-theia/vscode-builtin-extensions/pull/66"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

