### PR TITLE
gitpod: update dockerfile for keytar

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -11,6 +11,8 @@ RUN sudo apt-get update \
     && sudo apt-get install -y libgtk-3-0 libnss3 libasound2 libgbm1 \
     # native-keymap
     && sudo apt-get install -y libx11-dev libxkbfile-dev \
+    # keytar
+    && sudo apt-get install -y libsecret-1-dev \
     && sudo rm -rf /var/lib/apt/lists/*
 
 ENV NODE_VERSION="12.14.1"


### PR DESCRIPTION
**Description**

The commit updates the `.gitpod.dockerfile` to include the native `libsecret-1-dev` dependency which is now necessary due to the inclusion of `keytar` upstream.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>