### PR TITLE
extension-pack: perform pack publishing after individual builtins

### DIFF
--- a/src/create-extension-pack.js
+++ b/src/create-extension-pack.js
@@ -17,7 +17,7 @@
 /*
  * Creates an extension package referencing all built-in extensions previously
  * created during build time i.e. by executing yarn
- * 
+ *
  * Extensions will be skipped if a corresponding .vsix file is not found under the 'dist'
  * folder and also not found under the extension registry.
  */
@@ -41,7 +41,7 @@ const { tag, force } = yargs.option('tag', {
 
 const packageJson = 'package.json'
 const categories = ['Extension Packs'];
-const packName = 'builtin-extension-pack';
+export const packName = 'builtin-extension-pack';
 const publisher = 'eclipse-theia';
 const repository = 'https://github.com/eclipse-theia/vscode-builtin-extensions';
 
@@ -161,7 +161,7 @@ the included extensions are already present - "built-in".
 
 Built-in extensions are built-along and included in \`VS Code\` and \`Code OSS\`.
 In consequence they may be expected to be present and used by other extensions.
-They are part of the [vscode GitHub repository](https://github.com/microsoft/vscode/tree/master/) and 
+They are part of the [vscode GitHub repository](https://github.com/microsoft/vscode/tree/master/) and
 generally contribute basic functionality such as textmate grammars, used for syntax-highlighting, for some
 of the most popular programming languages. In some cases, more substantial features are contributed through
 built-in extensions (e.g. Typescript, Markdown, git, ...). Please see the description above to learn what

--- a/src/publish-vsix.js
+++ b/src/publish-vsix.js
@@ -16,13 +16,13 @@
 
 /**
  * Publish individual built-in VS Code extensions to an
- * Open VSX registry (default: open-vsx.org) . It is 
+ * Open VSX registry (default: open-vsx.org) . It is
  * assumed that the extensions to be published are present
  * in directory "dist" at the root of this repo.
- * 
+ *
  * The publishing of the extensions is delegated to `ovsx`,
  * which uses the following environment variables to know
- * to which registry to publish-to and what personal 
+ * to which registry to publish-to and what personal
  * authentication token to use to authenticate:
  *  OVSX_REGISTRY_URL, OVSX_PAT
  */
@@ -30,41 +30,64 @@
 const fs = require('fs')
 const os = require('os');
 const ovsx = require('ovsx');
+const { packName } = require('./create-extension-pack.js');
 const { dist } = require('./paths.js');
 const { isPublished } = require('./version');
 
 (async () => {
     const result = [];
 
-    for (const vsix of fs.readdirSync(dist())) {
-        // e.g.: bat-1.45.1.vsix
-        //       css-language-features-1.45.1.vsix
-        //       bat-1.45.2-next.5763d909d5.vsix
-        //       css-language-features-1.45.2-next.5763d909d5.vsix
-        let regexp = /^([\w-]+)-([\d\w\.-]+)\.vsix$/m;
-        const matches = vsix.match(new RegExp(regexp));
-        let [, extension, version] = matches;
-        
-        // is this extension/version alteady published?
-        try {
-            let found = await isPublished(version, extension);
-            if (found) {
-                console.log(`Extension ${extension} v${version} is already published - skipping!`)
-                continue;
-            } 
-        } catch (e) {
-            console.log('error: ' + e)
+    // Publish individual builtin extensions.
+    for (const vsix of fs.readdirSync(dist([]))) {
+        if (vsix.startsWith(packName)) {
+            continue;
         }
-
-        console.log('publishing: ', dist(vsix), ' ...');
-        try {
-            await ovsx.publish({ extensionFile: dist(vsix), yarn: true });
-        } catch (error) {
-            console.log(`failed to publish ${vsix}: ${error}`);
-            console.log('Stopping here. Fix the problem and retry.\n');
-            process.exit(1);
-        }
-        result.push(`Successfully published ${vsix}`);        
+        const publishedVsix = publishExtension(vsix);
+        result.push(`Successfully published: ${publishedVsix}`);
     }
+
+    // Publish builtin extension-pack.
+    for (const vsix of fs.readdirSync(dist([]))) {
+        if (vsix.startsWith(packName)) {
+            const publishedVsix = publishExtension(vsix);
+            result.push(`Successfully published extension-pack: ${publishedVsix}`);
+        }
+    }
+
     console.log(result.join(os.EOL));
 })();
+
+/**
+ * Publish the extension.
+ * @param {*} vsix the vsix extension.
+ */
+async function publishExtension(vsix) {
+
+    // e.g.: bat-1.45.1.vsix
+    //       css-language-features-1.45.1.vsix
+    //       bat-1.45.2-next.5763d909d5.vsix
+    //       css-language-features-1.45.2-next.5763d909d5.vsix
+    let regexp = /^([\w-]+)-([\d\w\.-]+)\.vsix$/m;
+    const matches = vsix.match(new RegExp(regexp));
+    let [, extension, version] = matches;
+
+    // Determine if the extension/version is already published.
+    try {
+        let found = await isPublished(version, extension);
+        if (found) {
+            console.log(`Extension ${extension} v${version} is already published - skipping!`)
+        }
+    } catch (e) {
+        console.log('Error: ' + e)
+    }
+
+    console.log('Publishing: ', dist([vsix]), ' ...');
+    try {
+        await ovsx.publish({ extensionFile: dist([vsix]), yarn: true });
+    } catch (error) {
+        console.log(`Failed to publish ${vsix}: ${error}`);
+        console.log('Stopping here. Fix the problem and retry.\n');
+        process.exit(1);
+    }
+    return vsix;
+}


### PR DESCRIPTION
Fixes: https://github.com/eclipse-theia/vscode-builtin-extensions/issues/69.

The commit updates the `publish-vsix` script to perform the publishing of the builtin extension-pack
following the publishing of individual builtins. Previously, the publishing of the extension-pack would fail if
an individual builtin was not yet published to the registry, causing the entire workflow to fail.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

cc @alvsan09 

<a href="https://gitpod.io/#https://github.com/eclipse-theia/vscode-builtin-extensions/pull/70"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

