### PR TITLE
gh-actions: update publish-next workflow to use node 12

### DIFF
--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -30,7 +30,7 @@ jobs:
         name: Setup Build Environment
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - run: |
           cd vscode
           git fetch


### PR DESCRIPTION
Signed-off-by: Alvaro Sanchez-Leon <alvaro.sanchez-leon@ericsson.com>

<a href="https://gitpod.io/#https://github.com/eclipse-theia/vscode-builtin-extensions/pull/71"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

