### PR TITLE
Add missing `module.exports`

### DIFF
--- a/src/create-extension-pack.js
+++ b/src/create-extension-pack.js
@@ -41,7 +41,7 @@ const { tag, force } = yargs.option('tag', {
 
 const packageJson = 'package.json'
 const categories = ['Extension Packs'];
-export const packName = 'builtin-extension-pack';
+const packName = 'builtin-extension-pack';
 const publisher = 'eclipse-theia';
 const repository = 'https://github.com/eclipse-theia/vscode-builtin-extensions';
 
@@ -175,3 +175,5 @@ included as a dependency or be installed within an extension or plugin directory
 individual extension as a dependency.
 `;
 }
+
+module.exports = { packName };


### PR DESCRIPTION
Add missing `module.exports` to `create-extension-pack` to re-use `packName` constant, and remove `export`.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

<a href="https://gitpod.io/#https://github.com/eclipse-theia/vscode-builtin-extensions/pull/72"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

