### PR TITLE
Fix importing packname

### DIFF
--- a/src/create-extension-pack.js
+++ b/src/create-extension-pack.js
@@ -175,5 +175,3 @@ included as a dependency or be installed within an extension or plugin directory
 individual extension as a dependency.
 `;
 }
-
-module.exports = { packName };

--- a/src/publish-vsix.js
+++ b/src/publish-vsix.js
@@ -30,9 +30,9 @@
 const fs = require('fs')
 const os = require('os');
 const ovsx = require('ovsx');
-const { packName } = require('./create-extension-pack.js');
 const { dist } = require('./paths.js');
 const { isPublished } = require('./version');
+const packName = 'builtin-extension-pack';
 
 (async () => {
     const result = [];


### PR DESCRIPTION
Fixes: #76 

Exporting and then importing of 'packName' triggered the execution of the `create-extension-pack` during the evaluation of the module when using `require`, the module will fail as it requires mandatory parameters.
This is solved by duplicating the variable (A refactoring is differed until we have the need to share additional constants).

<a href="https://gitpod.io/#https://github.com/eclipse-theia/vscode-builtin-extensions/pull/77"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

