### PR TITLE
publish: make publishing of extensions more robust

### DIFF
--- a/src/publish-vsix.js
+++ b/src/publish-vsix.js
@@ -75,19 +75,15 @@ async function publishExtension(vsix) {
     try {
         let found = await isPublished(version, extension);
         if (found) {
-            console.log(`Extension ${extension} v${version} is already published - skipping!`)
+            console.log(`Extension ${extension} v${version} is already published - skipping!`);
+        } else {
+            console.log('Publishing: ', dist(vsix), ' ...');
+            await ovsx.publish({ extensionFile: dist(vsix), yarn: true });
         }
+        return vsix;
     } catch (e) {
-        console.log('Error: ' + e)
-    }
-
-    console.log('Publishing: ', dist(vsix), ' ...');
-    try {
-        await ovsx.publish({ extensionFile: dist(vsix), yarn: true });
-    } catch (error) {
-        console.log(`Failed to publish ${vsix}: ${error}`);
+        console.log('Error: ' + e);
         console.log('Stopping here. Fix the problem and retry.\n');
         process.exit(1);
     }
-    return vsix;
 }


### PR DESCRIPTION
**Description**

The commit updates the `publishExtension` script to only attempt to publish extensions if they do not yet exist in the registry.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

<a href="https://gitpod.io/#https://github.com/eclipse-theia/vscode-builtin-extensions/pull/78"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

