### PR TITLE
temporarily disable publish to open-vsx

### DIFF
--- a/.github/workflows/publish-vsx-latest.yml
+++ b/.github/workflows/publish-vsx-latest.yml
@@ -1,10 +1,10 @@
 name: ovsx-solid---publish-vscode-built-in-extensions
 on:
-  schedule:
-    - cron: "0 0 * * *"
-  push:
-    branches:
-      - master
+  # schedule:
+  #   - cron: "0 0 * * *"
+  # push:
+  #   branches:
+  #     - master
 env:
   NODE_OPTIONS: --max-old-space-size=8192
 jobs:

--- a/.github/workflows/publish-vsx-next.yml
+++ b/.github/workflows/publish-vsx-next.yml
@@ -1,7 +1,7 @@
 name: ovsx-preview--publish-vscode-built-in-extensions
 on:
-  schedule:
-    - cron: "30 0 * * *"
+  # schedule:
+  #   - cron: "30 0 * * *"
   push:
     branches:
       - master


### PR DESCRIPTION
Fixes #93

1. disable open-vsx publish for solid revisions
Disable both nightly and when merging to master. This way we will not
further "pollute" the versions ahead of time, pass the current 1.62.3. We will
re-enable solid revision publish when we catch up and need more recent versions
published.

in the meantime we keep the build, so we see if problems arise.

2. disable cron nightly open-vsx publish for internediary revisions (next)

Keep publishing, when merging to master, so we can confirm that publishing still
works, but remove nightly CRON publishing. Given the relative activity in this repo, 
this will not result in a ton of next revisions on open-vsx.

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>

<a href="https://gitpod.io/#https://github.com/eclipse-theia/vscode-builtin-extensions/pull/94"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

