### PR TITLE
follow-up: disable publishing

### DIFF
--- a/.github/workflows/publish-vsx-latest.yml
+++ b/.github/workflows/publish-vsx-latest.yml
@@ -1,10 +1,10 @@
 name: ovsx-solid---publish-vscode-built-in-extensions
 on:
-  # schedule:
-  #   - cron: "0 0 * * *"
-  # push:
-  #   branches:
-  #     - master
+  schedule:
+    - cron: "0 0 * * *"
+  push:
+    branches:
+      - master
 env:
   NODE_OPTIONS: --max-old-space-size=8192
 jobs:
@@ -43,5 +43,5 @@ jobs:
         name: Package Solid Version of Extensions
       - run: yarn create-extension-pack:latest
         name: Create built-in extensions pack
-      - run: yarn publish:vsix
-        name: Publish Extensions to open-vsx.org
+      # - run: yarn publish:vsix
+      #   name: Publish Extensions to open-vsx.org

--- a/.github/workflows/publish-vsx-next.yml
+++ b/.github/workflows/publish-vsx-next.yml
@@ -1,7 +1,7 @@
 name: ovsx-preview--publish-vscode-built-in-extensions
 on:
-  # schedule:
-  #   - cron: "30 0 * * *"
+  schedule:
+    - cron: "30 0 * * *"
   push:
     branches:
       - master
@@ -42,5 +42,5 @@ jobs:
         name: Package Preview Version of Extensions
       - run: yarn create-extension-pack:next
         name: Create built-in extensions pack
-      - run: yarn publish:vsix
-        name: Publish Extensions to open-vsx.org
+      # - run: yarn publish:vsix
+      #   name: Publish Extensions to open-vsx.org


### PR DESCRIPTION
Try something a bit different: let CI happen on the same
triggers as before, but comment-out publishing to open-vsx. We
can still publish by pushing to one of the project's magic
branches, to test everything still works, as needed.

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>

<a href="https://gitpod.io/#https://github.com/eclipse-theia/vscode-builtin-extensions/pull/95"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

