### PR TITLE
[DO NOT MERGE YET] ][extension pack] Add ms-vscode.vscode-js-profile-table

### DIFF
--- a/src/create-extension-pack.js
+++ b/src/create-extension-pack.js
@@ -52,7 +52,7 @@ const repository = 'https://github.com/eclipse-theia/vscode-builtin-extensions';
  * https://github.com/microsoft/vscode/blob/1.57.0/product.json#L34-L126
  */
 const externalBuiltins = ['ms-vscode.node-debug', 'ms-vscode.node-debug2', 'ms-vscode.references-view',
-    'ms-vscode.js-debug-companion', 'ms-vscode.js-debug'];
+    'ms-vscode.js-debug-companion', 'ms-vscode.vscode-js-profile-table', 'ms-vscode.js-debug'];
 
 (async () => {
     const vscodeVersion = await resolveVscodeVersion();


### PR DESCRIPTION
I noticed while building v1.55.2 that this extension is part of those that are fetched (rather than built in place), like ms-vscode.node-debug and a few others. So I'm adding its name to the pack.

[...]
[13:58:47] Starting bundle-marketplace-extensions-build ...
[13:58:47] Downloading extension: ms-vscode.node-debug@1.44.19 ...
[13:58:47] Downloading extension: ms-vscode.node-debug2@1.42.5 ...
[13:58:47] Downloading extension: ms-vscode.references-view@0.0.77 ...
[13:58:47] Downloading extension: ms-vscode.js-debug-companion@1.0.9 ...
[13:58:47] Downloading extension: ms-vscode.js-debug@1.55.2 ...
[13:58:47] Downloading extension: __ms-vscode.vscode-js-profile-table__@0.0.11 ...


<a href="https://gitpod.io/#https://github.com/eclipse-theia/vscode-builtin-extensions/pull/103"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

