### PR TITLE
Builtins for 1.70.2

### DIFF
--- a/.github/workflows/publish-vsx-latest.yml
+++ b/.github/workflows/publish-vsx-latest.yml
@@ -30,7 +30,7 @@ jobs:
         name: Setup Build Environment
       - uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 16
       - run: |
           cd vscode
           git fetch --tags

--- a/.github/workflows/publish-vsx-next.yml
+++ b/.github/workflows/publish-vsx-next.yml
@@ -30,7 +30,7 @@ jobs:
         name: Setup Build Environment
       - uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 16
       - run: |
           cd vscode
           git fetch --tags

--- a/.github/workflows/publish-vsx-specific-latest.yml
+++ b/.github/workflows/publish-vsx-specific-latest.yml
@@ -28,7 +28,7 @@ jobs:
         name: Setup Build Environment
       - uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 16
       - run: npx ovsx --version
         name: Check ovsx version
       - run: yarn

--- a/.github/workflows/publish-vsx-specific-next.yml
+++ b/.github/workflows/publish-vsx-specific-next.yml
@@ -28,7 +28,7 @@ jobs:
         name: Setup Build Environment
       - uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 16
       - run: npx ovsx --version
         name: Check ovsx version
       - run: yarn

--- a/src/create-extension-pack.js
+++ b/src/create-extension-pack.js
@@ -51,8 +51,7 @@ const repository = 'https://github.com/eclipse-theia/vscode-builtin-extensions';
  * fetched by vscode at build time.
  * file://./..//vscode/product.json#builtInExtensions
  */
-const externalBuiltins = ['ms-vscode.references-view',
-    'ms-vscode.js-debug-companion', 'ms-vscode.js-debug'];
+const externalBuiltins = ['ms-vscode.js-debug-companion', 'ms-vscode.js-debug'];
 
 (async () => {
     const vscodeVersion = await resolveVscodeVersion();


### PR DESCRIPTION
Also contains a couple of commits, made earlier this year, for v1.66.2. We've already published v1.70.2 using the `ovsx-publish` "magic branch". The goal of merging this PR is just to be able to use it as the base for the next version we'll need to publish. 

update: removed "ms-vscode.references-view" from builtin pack. Unfortunately I missed this before publishing. If it causes issues to have both this one and the new "vscode.references-view" at the same time, we'll have to momentarily exclude the former using `theiaPluginsExcludeIds` in the app's package.json. 
