### PR TITLE
Include missing media files in generated 'vsix's

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -27,10 +27,11 @@ if (process.cwd() !== vscode()) {
 
 async function compileExtensions() {
     // @ts-ignore
-    const { compileExtensionsBuildTask, compileWebExtensionsTask } = require('../vscode/build/gulpfile.extensions.js')
+    const { compileExtensionsBuildTask, compileExtensionMediaTask, compileWebExtensionsTask } = require('../vscode/build/gulpfile.extensions.js')
     await createMissingLockFiles(vscodeExtensions());
     compileExtensionsBuildTask();
     compileWebExtensionsTask();
+    compileExtensionMediaTask();
 }
 
 async function createMissingLockFiles(extensionsPath) {


### PR DESCRIPTION
#### What it does

Fixes: https://github.com/eclipse-theia/vscode-builtin-extensions/issues/116

Adding the missing compilation step 'compileExtensionMediaTask'
This step (function) is already available in the 'vscode' baseline sub-module.

#### How to test
1) Using this change and the procedures on this repository `README.md`, build `vsix` files for the latest `vscode` sub-module.
NOTE: Use the --force option to produce `vsix` files which are already available in the market place e.g. 
> yarn package-vsix:latest --force

2) Build `theia` from a repository using the latest `master`
3) Remove the existing version of `vscode.simple-browser` from the the `theia` plugins folder
4) Copy the generated file `.../vscode-builtin-extensions/dist/simple-browser-1.70.2.vsix` to your `thiea` repo, `plugins` folder
The generated file should match the following:
[simple-browser-1.70.2.zip](https://github.com/eclipse-theia/vscode-builtin-extensions/files/11518493/simple-browser-1.70.2.zip)

5) Start `theia` and from the command palette execute the command `Simple Browser: Show`)
    -> on the input box enter the following site: `https://xkcd.com/`
4) Verify that the page open as expected.

NOTE: This browser may not work for many sites, but that's a separate issue to follow up after the true implementation of this stubbed API.

