### PR TITLE
Log error messages generated when publishing

### DIFF
--- a/src/publish-vsix.js
+++ b/src/publish-vsix.js
@@ -79,13 +79,20 @@ async function publishExtension(vsix) {
     // Determine if the extension/version is already published.
     try {
         let found = await isPublished(version, extension);
+        let message = `Successfully published extension: ${vsix}\n`;
         if (found) {
             console.log(`Extension ${extension} v${version} is already published - skipping!`);
         } else {
             console.log('Publishing: ', dist(vsix), ' ...');
-            await ovsx.publish({ extensionFile: dist(vsix), yarn: true });
+            const results = await ovsx.publish({ extensionFile: dist(vsix), yarn: true });
+            for (const result of results) {
+                if (result.status === 'rejected') {
+                    message = `Error(s) Generated when publishing ${extension} v${version}!`;
+                    console.log(result.reason);
+                }
+            }
+            console.log(message);
         }
-        console.log(`Successfully published extension: ${vsix}\n`);
         return vsix;
     } catch (e) {
         console.error(`Skipping publishing of: ${vsix}.\n`);


### PR DESCRIPTION
This change logs the error messages generated when publishing individual extensions to `open-vsx`,
This errors are very valuable for trouble shooting.

#### Testing
The testing has been performed by publishing this change to the `ovsx-publish` branch from the current master.
where the extension `builtin-notebook-renderers` version `1.77.0` is currently not properly publishing.
