### PR TITLE
Little improvements

### DIFF
--- a/src/publish-vsix.js
+++ b/src/publish-vsix.js
@@ -40,7 +40,7 @@ const packName = 'builtin-extension-pack';
     const extensions = fs.readdirSync(dist());
 
     /** The queue for individual builtin extensions. */
-    const builtinQueue = new PQueue({ concurrency: 4 });
+    const builtinQueue = new PQueue({ concurrency: 1 });
     /** The queue for extension packs. */
     const packQueue = new PQueue({ concurrency: 1 });
 

--- a/src/version.js
+++ b/src/version.js
@@ -54,11 +54,14 @@ async function resolveVscodeVersion() {
  * set registry (default: https://open-vsx.org)
  */
 async function isPublished(version, extension, namespace = 'vscode') {
-    let registry = process.env.OVSX_REGISTRY_URL ? process.env.OVSX_REGISTRY_URL : OPEN_VSX_ORG_URL;
-    const response = await fetch(`${registry}/api/${namespace}/${extension}/${version}`);
-    const json = await response.json();
-    // namespace/ext/version not found
-    return !json.error;
+    try {
+        const registry = process.env.OVSX_REGISTRY_URL ? process.env.OVSX_REGISTRY_URL : OPEN_VSX_ORG_URL;
+        const response = await fetch(`${registry}/api/${namespace}/${extension}/${version}`);
+        return response.ok;
+    } catch (e) {
+        console.log(e);
+        return false;
+    }
 }
 
 module.exports = { computeVersion, isPublished, resolveVscodeVersion };


### PR DESCRIPTION
Two main improvements are contained in this PR, each have their commit since not directly related.

### Improve version:isPublished()

I think what's there technically worked but this is cleaner

### [publish] Set builtinQueue concurrency to 1

It might result in slightly slower publish because extensions will
be published sequentially (previously it was 4 in parallel), but I
think it's safer this way. When we publish several extensions at the
same time, error handling is tricky.

For example: in publish-vsix.js line 87, we call ovsx.publish(). In
most error cases, except if an extension is already published, it
will throw. In the catch() block line 100, we re-throw, causing the
script to immediately exit with an error status.

Should the above happen in the middle of publishing, it could potentially
affect up-to 3 other extensions that were being published in parallel. It
seems that it could result in e.g. partially uploaded extensions, and
some publish being abandoned without being completed.

Hopefully, such cases are handled well by the server, but better to not
provoke them when possible.

