### PR TITLE
Update node version for publishing actions

### DIFF
--- a/.github/workflows/publish-vsx-latest.yml
+++ b/.github/workflows/publish-vsx-latest.yml
@@ -19,18 +19,18 @@ jobs:
           git submodule init
           git submodule update
         name: Checkout VS Code
-      # should be aligned with https://github.com/microsoft/vscode/blob/8031c495a65de120560d27703c415eb44c3a99a1/.github/workflows/ci.yml#L22-L32
+      # should be aligned with https://github.com/microsoft/vscode/blob/f1a4fb101478ce6ec82fe9627c43efbf9e98c813/.github/workflows/ci.yml#L108
       - run: |
           sudo apt-get update
-          sudo apt-get install -y libxkbfile-dev pkg-config libkrb5-dev libxss1 dbus xvfb libgtk-3-0 libgbm1
+          sudo apt-get install -y libxkbfile-dev pkg-config libsecret-1-dev libxss1 dbus xvfb libgtk-3-0
           sudo cp vscode/build/azure-pipelines/linux/xvfb.init /etc/init.d/xvfb
           sudo chmod +x /etc/init.d/xvfb
           sudo update-rc.d xvfb defaults
           sudo service xvfb start
         name: Setup Build Environment
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version-file: vscode/.nvmrc
       - run: yarn
         name: Install Dependencies
       - run: |

--- a/.github/workflows/publish-vsx-next.yml
+++ b/.github/workflows/publish-vsx-next.yml
@@ -19,18 +19,18 @@ jobs:
           git submodule init
           git submodule update
         name: Checkout VS Code
-      # should be aligned with https://github.com/microsoft/vscode/blob/8031c495a65de120560d27703c415eb44c3a99a1/.github/workflows/ci.yml#L22-L32
+      # should be aligned with https://github.com/microsoft/vscode/blob/f1a4fb101478ce6ec82fe9627c43efbf9e98c813/.github/workflows/ci.yml#L108
       - run: |
           sudo apt-get update
-          sudo apt-get install -y libxkbfile-dev pkg-config libkrb5-dev libxss1 dbus xvfb libgtk-3-0 libgbm1
+          sudo apt-get install -y libxkbfile-dev pkg-config libsecret-1-dev libxss1 dbus xvfb libgtk-3-0
           sudo cp vscode/build/azure-pipelines/linux/xvfb.init /etc/init.d/xvfb
           sudo chmod +x /etc/init.d/xvfb
           sudo update-rc.d xvfb defaults
           sudo service xvfb start
         name: Setup Build Environment
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version-file: vscode/.nvmrc
       - run: |
           cd vscode
           git fetch --tags

--- a/.github/workflows/publish-vsx-specific-latest.yml
+++ b/.github/workflows/publish-vsx-specific-latest.yml
@@ -17,18 +17,18 @@ jobs:
           git submodule init
           git submodule update
         name: Checkout VS Code
-      # should be aligned with https://github.com/microsoft/vscode/blob/8031c495a65de120560d27703c415eb44c3a99a1/.github/workflows/ci.yml#L22-L32
+      # should be aligned with https://github.com/microsoft/vscode/blob/f1a4fb101478ce6ec82fe9627c43efbf9e98c813/.github/workflows/ci.yml#L108
       - run: |
           sudo apt-get update
-          sudo apt-get install -y libxkbfile-dev pkg-config libkrb5-dev libxss1 dbus xvfb libgtk-3-0 libgbm1
+          sudo apt-get install -y libxkbfile-dev pkg-config libsecret-1-dev libxss1 dbus xvfb libgtk-3-0
           sudo cp vscode/build/azure-pipelines/linux/xvfb.init /etc/init.d/xvfb
           sudo chmod +x /etc/init.d/xvfb
           sudo update-rc.d xvfb defaults
           sudo service xvfb start
         name: Setup Build Environment
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version-file: vscode/.nvmrc
       - run: npx ovsx --version
         name: Check ovsx version
       - run: |

--- a/.github/workflows/publish-vsx-specific-next.yml
+++ b/.github/workflows/publish-vsx-specific-next.yml
@@ -17,18 +17,18 @@ jobs:
           git submodule init
           git submodule update
         name: Checkout VS Code
-      # should be aligned with https://github.com/microsoft/vscode/blob/8031c495a65de120560d27703c415eb44c3a99a1/.github/workflows/ci.yml#L22-L32
+      # should be aligned with https://github.com/microsoft/vscode/blob/f1a4fb101478ce6ec82fe9627c43efbf9e98c813/.github/workflows/ci.yml#L108
       - run: |
           sudo apt-get update
-          sudo apt-get install -y libxkbfile-dev pkg-config libxkbfile-dev pkg-config libkrb5-dev libxss1 dbus xvfb libgtk-3-0 libgbm1
+          sudo apt-get install -y libxkbfile-dev pkg-config libsecret-1-dev libxss1 dbus xvfb libgtk-3-0
           sudo cp vscode/build/azure-pipelines/linux/xvfb.init /etc/init.d/xvfb
           sudo chmod +x /etc/init.d/xvfb
           sudo update-rc.d xvfb defaults
           sudo service xvfb start
         name: Setup Build Environment
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version-file: vscode/.nvmrc
       - run: npx ovsx --version
         name: Check ovsx version
       - run: |


### PR DESCRIPTION
This makes use of the `.nvmrc` file within `vscode` to ensure that we always use the same version of node as VS Code when building. Also updates our native apt-get instructions for the latest versions of VS Code.

Afterwards, I can perform the automated release.